### PR TITLE
Fix format-security error

### DIFF
--- a/GP/gpiKeys.c
+++ b/GP/gpiKeys.c
@@ -181,7 +181,7 @@ GPResult gpiSaveKeysToBuffer(GPConnection *connection, char **buffer)
 		gsDebugFormat(GSIDebugCat_GP, GSIDebugType_Memory, GSIDebugLevel_HotError, "gpiSaveKeysToBuffer: buffer Out of memory.");
 		Error(connection, GP_MEMORY_ERROR, "Out of memory.");
 	}
-	bytesWritten = sprintf(*buffer, keysHeader);
+	bytesWritten = sprintf(*buffer, "%s", keysHeader);
 	tempPoint = *buffer + bytesWritten;
 	for (i = 0; i < aLength; i++)
 	{


### PR DESCRIPTION
Fork PR: https://github.com/OpenXRay/GameSpy/pull/6

Compiling with GCC and `-Wformat-security -Werror=format-security` (default on some Linux distributions) throws the following error:

```
[ 80%] Building C object GP/CMakeFiles/rsgp.dir/gpiOperation.c.o
/build/source/GP/gpiKeys.c: In function 'gpiSaveKeysToBuffer':
/build/source/GP/gpiKeys.c:184:34: error: format not a string literal and no format arguments [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wformat-security-Werror=format-security8;;]
  184 |  bytesWritten = sprintf(*buffer, keysHeader);
      |                                  ^~~~~~~~~~
```

Fix is simple, just add a format strings `"%s"` to properly print the string.